### PR TITLE
Update TomcatVaultApplication.java

### DIFF
--- a/tomcat-vault-example/src/main/java/com/redhat/jws/quickstart/TomcatVaultApplication.java
+++ b/tomcat-vault-example/src/main/java/com/redhat/jws/quickstart/TomcatVaultApplication.java
@@ -36,7 +36,8 @@ public class TomcatVaultApplication {
 
         // Add an instance of the servlet and add the servlet mapping
         Tomcat.addServlet(ctx, "hello", new HelloServlet());
-        ctx.addServletMapping("/hello", "hello");
+        //Replaced deprecated method with 9.0.6 new method
+        ctx.addServletMappingDecoded("/hello", "hello");
 
         // Grab a reference to vault.properties from src/main/resources/ which will point to all of
         // the other configuration files needed; they are also in src/main/resources/.


### PR DESCRIPTION
The "addServletMapping(String, String)" method is not present in the 9.0.6 version of the api. Instead it has been replaced with "addServletMappingDecoded(String, String)".